### PR TITLE
add var to get the correct NodeGroup

### DIFF
--- a/deploy/eks/prep.yaml
+++ b/deploy/eks/prep.yaml
@@ -33,7 +33,7 @@ data:
   FLASK_ENV: "production"
   NODE_ENV: "production"
   # AWS Configuration
-  AWS_REGION: "us-west-2"
+  AWS_REGION: "eu-west-1"
   ORDER_QUEUE: "demostore-orderqueue"
   # Service Endpoints
   CATALOG_ENDPOINT: "catalogservice"

--- a/deploy/eks/prep.yaml
+++ b/deploy/eks/prep.yaml
@@ -33,7 +33,7 @@ data:
   FLASK_ENV: "production"
   NODE_ENV: "production"
   # AWS Configuration
-  AWS_REGION: "eu-west-1"
+  AWS_REGION: "us-west-2"
   ORDER_QUEUE: "demostore-orderqueue"
   # Service Endpoints
   CATALOG_ENDPOINT: "catalogservice"

--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -29,8 +29,11 @@ helm del --purge grafana
 Detach IAM roles from the EKS worker node group IAM role. This needs to be done before removing the CloudFormation Stack.
 
 ```bash
-# Get IAM instance profile
-PROFILE=$(aws ec2 describe-instances --filters --filters Name=tag:Name,Values=dev303-workshop-0-Node --query 'Reservations[0].Instances[0].IamInstanceProfile.Arn' --output text | cut -d '/' -f 2)
+# Get the nodegroup (assuming there is only 1 nodegroup at this point)
+NODEGROUP=$(eksctl get nodegroups --cluster=dev303-workshop | awk '{print $2}' | tail -n1)
+
+# Get EKS worker node IAM instance role ARN
+PROFILE=$(aws ec2 describe-instances --filters Name=tag:Name,Values=dev303-workshop-$NODEGROUP-Node --query 'Reservations[0].Instances[0].IamInstanceProfile.Arn' --output text | cut -d '/' -f 2)
 
 # Get EKS worker node IAM role
 ROLE=$(aws iam get-instance-profile --instance-profile-name $PROFILE --query "InstanceProfile.Roles[0].RoleName" --output text)

--- a/docs/lab1.md
+++ b/docs/lab1.md
@@ -12,7 +12,7 @@ Use the following command to create your **EKS** cluster **without** adding ssh 
 ```bash
 eksctl create cluster \
 --name dev303-workshop \
---region eu-west-1 \
+--region us-west-2 \
 --nodes=4
 ```
 
@@ -21,12 +21,12 @@ eksctl create cluster \
 ```bash
 eksctl create cluster \
 --name dev303-workshop \
---region eu-west-1 \
+--region us-west-2 \
 --nodes=4
 --ssh-access --ssh-public-key=myid_rsa_ssh_key.pub
 ```
 
-This will create a cluster in the eu-west-1 (Ireland) region with 4 x m5.large instances.
+This will create a cluster in the us-west-2 (Oregon) region with 4 x m5.large instances.
 
 > **Note**
 > 
@@ -42,10 +42,10 @@ and you should see a list of nodes:
 ```bash
 $ kubectl get nodes
 NAME                                           STATUS    ROLES     AGE       VERSION
-ip-192-168-29-95.eu-west-1.compute.internal    Ready     <none>    2m        v1.10.3
-ip-192-168-62-87.eu-west-1.compute.internal    Ready     <none>    2m        v1.10.3
-ip-192-168-70-32.eu-west-1.compute.internal    Ready     <none>    2m        v1.10.3
-ip-192-168-74-223.eu-west-1.compute.internal   Ready     <none>    2m        v1.10.3
+ip-192-168-29-95.us-west-2.compute.internal    Ready     <none>    2m        v1.10.3
+ip-192-168-62-87.us-west-2.compute.internal    Ready     <none>    2m        v1.10.3
+ip-192-168-70-32.us-west-2.compute.internal    Ready     <none>    2m        v1.10.3
+ip-192-168-74-223.us-west-2.compute.internal   Ready     <none>    2m        v1.10.3
 ```
 
 ## Deploy "AnyCompany Shop" microservices application
@@ -63,7 +63,7 @@ Use the CloudFormation template to create a new Stack in the CloudFormation cons
 ```bash
 aws cloudformation create-stack \
 --stack-name dev303-workshop \
---template-url https://s3.amazonaws.com/aws-tracing-workshop-artifacts/cloudformation.yaml --capabilities CAPABILITY_NAMED_IAM --region eu-west-1
+--template-url https://s3.amazonaws.com/aws-tracing-workshop-artifacts/cloudformation.yaml --capabilities CAPABILITY_NAMED_IAM --region us-west-2
 ```
 
 ##### *UI Walkthrough*
@@ -86,7 +86,7 @@ First, deploy the definitions to prepare the environment. This step creates a Ku
 
 > **Note**
 >
-> If you are not deploying to the *eu-west-1* region you need to update the AWS_REGION variable in the following file `deploy/eks/prep.yaml` to point to the region used.
+> If you are not deploying to the *us-west-2* region you need to update the AWS_REGION variable in the following file `deploy/eks/prep.yaml` to point to the region used.
 
 ```
 kubectl create -f deploy/eks/prep.yaml

--- a/docs/lab1.md
+++ b/docs/lab1.md
@@ -83,8 +83,12 @@ kubectl create -f deploy/eks/prep.yaml
 
 Attach the necessary IAM policies to the worker nodes. This will enable containers running on these nodes to access AWS resources. Two of the services you will deploy in the next step are making use of this to access DynamoDB and SQS.
 ```bash
+
+# Get the nodegroup (assuming there is only 1 nodegroup at this point)
+NODEGROUP=$(eksctl get nodegroups --cluster=dev303-workshop | awk '{print $2}' | tail -n1)
+
 # Get EKS worker node IAM instance role ARN
-PROFILE=$(aws ec2 describe-instances --filters Name=tag:Name,Values=dev303-workshop-0-Node --query 'Reservations[0].Instances[0].IamInstanceProfile.Arn' --output text | cut -d '/' -f 2)
+PROFILE=$(aws ec2 describe-instances --filters Name=tag:Name,Values=dev303-workshop-$NODEGROUP-Node --query 'Reservations[0].Instances[0].IamInstanceProfile.Arn' --output text | cut -d '/' -f 2)
 
 # Fetch IAM instance role name
 ROLE=$(aws iam get-instance-profile --instance-profile-name $PROFILE --query "InstanceProfile.Roles[0].RoleName" --output text)

--- a/docs/lab1.md
+++ b/docs/lab1.md
@@ -74,6 +74,10 @@ Click **Next** on the *following* screen, leaving everything unchanged until you
 
 First, deploy the definitions to prepare the environment. This step creates a Kubernetes **namespace** for the microservices and configures the **environment**.
 
+> **Note**
+>
+> If you are not deploying to the *us-west-2* region you need to update the AWS_REGION variable in the following file `deploy/eks/prep.yaml` to point to the region used.
+
 ```
 kubectl create -f deploy/eks/prep.yaml
 ```

--- a/docs/lab1.md
+++ b/docs/lab1.md
@@ -7,16 +7,26 @@
 >
 > Double check that the required tooling is installed before creating a cluster. You need to have the AWS CLI installed and configured and `kubectl` must is installed as well.
 
-Use the following command to create your **EKS** cluster:
+Use the following command to create your **EKS** cluster **without** adding ssh keys for access to the worker nodes (ssh access is not required to complete the workshop!):
 
 ```bash
 eksctl create cluster \
 --name dev303-workshop \
---region us-west-2 \
+--region eu-west-1 \
 --nodes=4
 ```
 
-This will create a cluster in the us-west-2 (Oregon) region with 4 x m5.large instances.
+**Advanced** Use the following command to create your **EKS** cluster **adding** ssh keys for access to the worker nodes (first generate your ssh keypair if not done already):
+
+```bash
+eksctl create cluster \
+--name dev303-workshop \
+--region eu-west-1 \
+--nodes=4
+--ssh-access --ssh-public-key=myid_rsa_ssh_key.pub
+```
+
+This will create a cluster in the eu-west-1 (Ireland) region with 4 x m5.large instances.
 
 > **Note**
 > 
@@ -32,10 +42,10 @@ and you should see a list of nodes:
 ```bash
 $ kubectl get nodes
 NAME                                           STATUS    ROLES     AGE       VERSION
-ip-192-168-29-95.us-west-2.compute.internal    Ready     <none>    2m        v1.10.3
-ip-192-168-62-87.us-west-2.compute.internal    Ready     <none>    2m        v1.10.3
-ip-192-168-70-32.us-west-2.compute.internal    Ready     <none>    2m        v1.10.3
-ip-192-168-74-223.us-west-2.compute.internal   Ready     <none>    2m        v1.10.3
+ip-192-168-29-95.eu-west-1.compute.internal    Ready     <none>    2m        v1.10.3
+ip-192-168-62-87.eu-west-1.compute.internal    Ready     <none>    2m        v1.10.3
+ip-192-168-70-32.eu-west-1.compute.internal    Ready     <none>    2m        v1.10.3
+ip-192-168-74-223.eu-west-1.compute.internal   Ready     <none>    2m        v1.10.3
 ```
 
 ## Deploy "AnyCompany Shop" microservices application
@@ -53,7 +63,7 @@ Use the CloudFormation template to create a new Stack in the CloudFormation cons
 ```bash
 aws cloudformation create-stack \
 --stack-name dev303-workshop \
---template-url https://s3.amazonaws.com/aws-tracing-workshop-artifacts/cloudformation.yaml --capabilities CAPABILITY_NAMED_IAM
+--template-url https://s3.amazonaws.com/aws-tracing-workshop-artifacts/cloudformation.yaml --capabilities CAPABILITY_NAMED_IAM --region eu-west-1
 ```
 
 ##### *UI Walkthrough*
@@ -76,7 +86,7 @@ First, deploy the definitions to prepare the environment. This step creates a Ku
 
 > **Note**
 >
-> If you are not deploying to the *us-west-2* region you need to update the AWS_REGION variable in the following file `deploy/eks/prep.yaml` to point to the region used.
+> If you are not deploying to the *eu-west-1* region you need to update the AWS_REGION variable in the following file `deploy/eks/prep.yaml` to point to the region used.
 
 ```
 kubectl create -f deploy/eks/prep.yaml

--- a/docs/lab2.md
+++ b/docs/lab2.md
@@ -11,8 +11,11 @@ The `Fluentd-Policy` IAM policy enables the Fluentd daemon to upload logs to Clo
 
 Find the EKS worker nodes node group **IAM role arn**
 ```bash
+# Get the nodegroup (assuming there is only 1 nodegroup at this point)
+NODEGROUP=$(eksctl get nodegroups --cluster=dev303-workshop | awk '{print $2}' | tail -n1)
+
 # Get EKS worker node IAM instance role ARN
-PROFILE=$(aws ec2 describe-instances --filters Name=tag:Name,Values=*dev303-workshop* --query 'Reservations[0].Instances[0].IamInstanceProfile.Arn' --output text | cut -d '/' -f 2)
+PROFILE=$(aws ec2 describe-instances --filters Name=tag:Name,Values=dev303-workshop-$NODEGROUP-Node --query 'Reservations[0].Instances[0].IamInstanceProfile.Arn' --output text | cut -d '/' -f 2)
 
 # Fetch IAM instance role name
 ROLE=$(aws iam get-instance-profile --instance-profile-name $PROFILE --query "InstanceProfile.Roles[0].RoleName" --output text)

--- a/docs/lab3.md
+++ b/docs/lab3.md
@@ -15,7 +15,11 @@ Before we can deploy the AWS X-Ray daemon to the EKS cluster we need to apply th
 Find the name of your EKS **worker node group** and attach the **X-Ray IAM policy** to the worker nodes **IAM role**.
 
 ```bash
-PROFILE=$(aws ec2 describe-instances --filters Name=tag:Name,Values=*dev303* --query 'Reservations[0].Instances[0].IamInstanceProfile.Arn' --output text | cut -d '/' -f 2)
+# Get the nodegroup (assuming there is only 1 nodegroup at this point)
+NODEGROUP=$(eksctl get nodegroups --cluster=dev303-workshop | awk '{print $2}' | tail -n1)
+
+# Get EKS worker node IAM instance role ARN
+PROFILE=$(aws ec2 describe-instances --filters Name=tag:Name,Values=dev303-workshop-$NODEGROUP-Node --query 'Reservations[0].Instances[0].IamInstanceProfile.Arn' --output text | cut -d '/' -f 2)
 
 ROLE=$(aws iam get-instance-profile --instance-profile-name $PROFILE --query "InstanceProfile.Roles[0].RoleName" --output text)
 


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Fails when populating the PROFILE var if the NodeGroup is not 0. Adding the correct nodegroup id (last found by eksctl) in order to populate the PROFILE var

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
